### PR TITLE
Solution for Error in module 'tensorflow' has no attribute 'contrib'

### DIFF
--- a/chapter3/listing3.1.py
+++ b/chapter3/listing3.1.py
@@ -3,6 +3,8 @@ import os
 os.environ['TF_CPP_MIN_LOG_LEVEL']='2'
 
 import numpy as np
+
+%tensorflow_version 1.14
 import tensorflow as tf 
 
 """


### PR DESCRIPTION
Adding "%tensorflow_version 1.14" in code, so it will be enable the tensorflow to run the contrib in this function "tf.contrib.learn.datasets.base.load_csv_with_header"